### PR TITLE
docs: expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,44 @@
-# Firebase Studio
+# C-Insight
 
-This is a NextJS starter in Firebase Studio.
+C-Insight is an experimental web application that uses Google's Genkit and Gemini models to generate unit tests for C functions. The app is built with Next.js 15, Tailwind CSS, and Firebase App Hosting.
 
-To get started, take a look at src/app/page.tsx.
+## Features
+
+- Upload C code and specify a function to test.
+- Server actions validate input and invoke a Genkit flow to produce unit tests, mocks, and stubs.
+- UI built with Shadcn components and Radix primitives.
+- Project blueprint for future features like call-graph analysis and coverage reports.
+
+## Project Structure
+
+- `src/app` – Next.js app router pages, server actions, and global styles.
+- `src/components` – UI components such as `CodeInputForm`, `TestResults`, and `Header`.
+- `src/ai` – Genkit configuration and flows (e.g., `generate-unit-tests.ts`).
+- `docs/` – Additional documentation (`blueprint.md`, architecture docs).
+
+## Getting Started
+
+1. **Prerequisites**: Node.js 20+ and npm.
+2. **Install dependencies**: `npm install`.
+3. **Configure environment**: set `GOOGLE_AI_API_KEY` for Gemini access.
+4. **Run dev server**: `npm run dev` to start Next.js on port 9002.
+5. **Optional**: `npm run genkit:dev` to launch Genkit developer tools.
+6. **Build for production**: `npm run build` then `npm start`.
+
+## Scripts
+
+- `npm run dev` – Start Next.js development server.
+- `npm run genkit:dev` – Start Genkit development environment.
+- `npm run lint` – Run lint checks.
+- `npm run typecheck` – Run TypeScript type checks.
+- `npm run build` – Compile production bundle.
+
+## Contributing
+
+- Fork and clone the repository.
+- Create feature branches; ensure `npm run lint` and `npm run typecheck` pass before submitting pull requests.
+- See `docs/architecture.md` and `docs/blueprint.md` for design details and roadmap.
+
+## License
+
+No license has been specified yet.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,29 @@
+# Architecture
+
+This document provides an overview of how C-Insight is put together.
+
+## High Level Flow
+
+1. The **CodeInputForm** component collects C code and a target function.
+2. The `handleGenerateTests` server action validates input with Zod and calls the `generateUnitTests` flow.
+3. The Genkit flow uses Google's Gemini model to produce unit tests, mocks, and stubs.
+4. The **TestResults** component displays the generated artifacts or any errors.
+
+## Directory Layout
+
+- `src/app` – App router entry points, server actions, and global styles.
+- `src/components` – React components including forms and result tabs.
+- `src/ai` – Genkit configuration (`genkit.ts`) and flows (`flows/generate-unit-tests.ts`).
+- `src/hooks` – Custom React hooks such as `use-toast`.
+- `src/lib` – Utility functions.
+
+## Technology Stack
+
+- **Next.js 15** with the App Router and server actions.
+- **Tailwind CSS** and **Radix UI** for styling and components.
+- **Genkit** with the Google AI plugin targeting the `googleai/gemini-2.5-flash` model.
+- **Firebase App Hosting** configuration via `apphosting.yaml`.
+
+## Future Work
+
+Refer to `docs/blueprint.md` for the project roadmap, including call-graph parsing, coverage metrics, and CI integration.


### PR DESCRIPTION
## Summary
- replace placeholder README with setup instructions, project structure, and contributing notes
- add an architecture overview describing data flow, directory layout, and tech stack

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: missing module 'wav'; layout crossOrigin type error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d0e8e8c8323b79cfa1c415e4de5